### PR TITLE
move `lints` dependency under dev_dependencies

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,10 +19,4 @@ environment:
 
 dev_dependencies:
   test: ^1.16.0
-
-dependencies:
-  lints: ">=2.0.0"
-
-
-
-
+  lints: ^6.0.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -21,7 +21,7 @@ dev_dependencies:
   test: ^1.16.0
 
 dependencies:
-  lints: ^6.0.0
+  lints: ">=2.0.0"
 
 
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,4 +19,4 @@ environment:
 
 dev_dependencies:
   test: ^1.16.0
-  lints: ">=2.0.0"
+  lints: ^6.0.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,4 +19,4 @@ environment:
 
 dev_dependencies:
   test: ^1.16.0
-  lints: ^6.0.0
+  lints: ">=2.0.0"


### PR DESCRIPTION
```
This dependency requires updating to SDK version ^3.8.0-0: lints: ^6.0.0
```
Package consumers were experiencing errors when using this package with lower Dart SDK versions. This occurred because the `lint` package was incorrectly listed as a dependency instead of a dev dependency. This patch fixes the issue by moving the package to dev_dependencies.

FIXES https://github.com/shan-shaji/ansi-escapes-dart/issues/5, https://github.com/shan-shaji/ansi-escapes-dart/issues/6